### PR TITLE
Add placeholder index page

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ python main.py
 
 The API will be available at `http://localhost:5000/api`.
 
+A simple placeholder page is served at `http://localhost:5000`.
 Uploaded files are stored in the `src/uploads` directory and a SQLite database is created under `database/app.db` on first run.
 
 ## Notes

--- a/static/index.html
+++ b/static/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>AI Document Processor</title>
+    <style>
+      body { font-family: Arial, sans-serif; margin: 2rem; }
+    </style>
+  </head>
+  <body>
+    <h1>AI Document Processor</h1>
+    <p>The web interface for this project is not included. This Flask server provides an API for uploading documents and asking questions about them.</p>
+    <p>Refer to the <a href="README.md">README</a> for details.</p>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a minimal static/index.html so the server can serve an index
- mention the placeholder page in the README

## Testing
- `python -m py_compile main.py src/**/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6847bf3118648329a326027a9e3c429c